### PR TITLE
uxmhf: xmhf-uobjs/geec_prime: revise gp_s2_setupgdt to use CPU lapici…

### DIFF
--- a/uxmhf/configure.ac
+++ b/uxmhf/configure.ac
@@ -57,6 +57,15 @@ AS_IF([test "x${enable_debug_serial}" != "xno"],
        DEBUG_SERIAL_PORT=$[]enable_debug_serial],
       [DEBUG_SERIAL=n])
 
+#debugging
+AC_SUBST([DEBUG_SERIAL_MAXCPUS])
+AC_ARG_WITH([debug_serial_maxcpus],
+        AS_HELP_STRING([--with-debug-serial-maxcpus@<:@=CPUS@:>@],
+                [specify number of CPUS on the platform when debug mode is enabled]),
+                , [with_debug_serial_maxcpus=8])
+DEBUG_SERIAL_MAXCPUS=$[]with_debug_serial_maxcpus
+
+
 
 # selectively enable/disable Dynamic Root-of-Trust (DRT)
 AC_SUBST([DRT])

--- a/uxmhf/uxmhf-common.mk.in
+++ b/uxmhf/uxmhf-common.mk.in
@@ -31,6 +31,8 @@ export prefix=@prefix@
 
 export DEBUG_SERIAL := @DEBUG_SERIAL@
 export DEBUG_SERIAL_PORT := @DEBUG_SERIAL_PORT@
+export XMHF_CONFIG_DEBUG_SERIAL_MAXCPUS	:= @DEBUG_SERIAL_MAXCPUS@
+
 #export DEBUG_VGA := @DEBUG_VGA@
 export DRT := @DRT@
 export DMAP := @DMAP@
@@ -81,7 +83,6 @@ export XMHF_CONFIG_MAX_EXCLDEVLIST_ENTRIES := 6
 
 export XMHF_CONFIG_MAX_MEMOFFSET_ENTRIES := 64
 
-export XMHF_CONFIG_DEBUG_SERIAL_MAXCPUS	:= 8
 
 ## build version
 #export XMHF_BUILD_VERSION := $(shell git describe --abbrev=0)

--- a/uxmhf/xmhf-uobjs/geec_prime/gp_s2_setupgdt.c
+++ b/uxmhf/xmhf-uobjs/geec_prime/gp_s2_setupgdt.c
@@ -75,7 +75,7 @@ void gp_s2_setupgdt(void){
 	for(i=0; i < xcbootinfo->cpuinfo_numentries; i++){
 
 		if(xcbootinfo->cpuinfo_buffer[i].lapic_id < MAX_PLATFORM_CPUS){
-			gp_s2_setupgdt_setgdttssentry( ((__TRSEL/8)+(i)) , xcbootinfo->cpuinfo_buffer[i].lapic_id);
+			gp_s2_setupgdt_setgdttssentry( ((__TRSEL/8)+(xcbootinfo->cpuinfo_buffer[i].lapic_id)) , xcbootinfo->cpuinfo_buffer[i].lapic_id);
 			//@ghost gp_s2_setupgdt_invokehelper[i] = true;
 
 			_XDPRINTF_("%s: setup TSS CPU idx=%u with base address=%x, iobitmap=%x\n, size=%u bytes", __func__,


### PR DESCRIPTION
fix(uxmhf): support non-linear CPU id mappings setup by certain BIOSes