### PR TITLE
Fix build

### DIFF
--- a/uxmhf-rpi3/uobjcoll/uobjs/main/core/hypvtablestubs_data.c
+++ b/uxmhf-rpi3/uobjcoll/uobjs/main/core/hypvtablestubs_data.c
@@ -40,7 +40,7 @@
 
 #include <uberspark/uobjcoll/platform/rpi3/uxmhf/uobjs/main/include/types.h>
 
-_//_attribute__((section(".stack"))) __attribute__((aligned(8))) u32 hypvtable_stack[8192 / 4];
+//_attribute__((section(".stack"))) __attribute__((aligned(8))) u32 hypvtable_stack[8192 / 4];
 
 __attribute__((section(".stack"))) __attribute__((aligned(8))) u8 hypvtable_hypsvc_stack0[16384];
 

--- a/uxmhf-rpi3/uobjcoll/uobjs/main/uapps/uapp-i2c-ioaccess.c
+++ b/uxmhf-rpi3/uobjcoll/uobjs/main/uapps/uapp-i2c-ioaccess.c
@@ -59,8 +59,8 @@ bool uapp_va2pa_withoff(uint32_t va, u32 *pa){
   u32 par;
   u32 offset;
 
-  sysreg_ats1cpr(va);
-  par=sysreg_read_par();
+  CASM_FUNCCALL(sysreg_ats1cpr, va);
+  par=CASM_FUNCCALL(sysreg_read_par, CASM_NOPARAM);
 
   if(par & 0x1)
     return false;


### PR DESCRIPTION
fix(uxmhf-rpi3): revise uapp-i2c-ioaccess to use CASM_FUNCCALL to invoke sysreg_read_par
fix(uxmhf-rpi3): revise core/hypvtablestubs_data to fix typo for successful compilation
