### PR TITLE
Fix compiler errors in gcc 10.2.1

### DIFF
--- a/xmhf/Makefile.in
+++ b/xmhf/Makefile.in
@@ -151,6 +151,7 @@ CFLAGS += -mno-sse4.1 -mno-sse4.2 -mno-sse4 -mno-avx -mno-aes
 CFLAGS += -mno-pclmul -mno-sse4a -mno-sse5 -mno-3dnow -mno-popcnt -mno-abm
 CFLAGS += -nostdinc -pipe
 CFLAGS += -Wno-address-of-packed-member
+CFLAGS += -no-pie
 
 CFLAGS += $(ADDL_INCLUDES)
 VFLAGS = $(ADDL_INCLUDES)

--- a/xmhf/Makefile.in
+++ b/xmhf/Makefile.in
@@ -151,7 +151,7 @@ CFLAGS += -mno-sse4.1 -mno-sse4.2 -mno-sse4 -mno-avx -mno-aes
 CFLAGS += -mno-pclmul -mno-sse4a -mno-sse5 -mno-3dnow -mno-popcnt -mno-abm
 CFLAGS += -nostdinc -pipe
 CFLAGS += -Wno-address-of-packed-member
-CFLAGS += -no-pie
+CFLAGS += -fno-pie -fno-pic
 
 CFLAGS += $(ADDL_INCLUDES)
 VFLAGS = $(ADDL_INCLUDES)

--- a/xmhf/Makefile.in
+++ b/xmhf/Makefile.in
@@ -150,6 +150,7 @@ CFLAGS += -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-ssse3
 CFLAGS += -mno-sse4.1 -mno-sse4.2 -mno-sse4 -mno-avx -mno-aes 
 CFLAGS += -mno-pclmul -mno-sse4a -mno-sse5 -mno-3dnow -mno-popcnt -mno-abm
 CFLAGS += -nostdinc -pipe
+CFLAGS += -Wno-address-of-packed-member
 
 CFLAGS += $(ADDL_INCLUDES)
 VFLAGS = $(ADDL_INCLUDES)

--- a/xmhf/hypapps/trustvisor/src/tlsf.c
+++ b/xmhf/hypapps/trustvisor/src/tlsf.c
@@ -370,11 +370,11 @@ static block_header_t* search_suitable_block(pool_t* pool, int* fli, int* sli)
 	** First, search for a block in the list associated with the given
 	** fl/sl index.
 	*/
-	unsigned int sl_map = pool->sl_bitmap[fl] & (~0 << sl);
+	unsigned int sl_map = pool->sl_bitmap[fl] & (~0UL << sl);
 	if (!sl_map)
 	{
 		/* No block exists. Search in the next largest first-level list. */
-		const unsigned int fl_map = pool->fl_bitmap & (~0 << (fl + 1));
+		const unsigned int fl_map = pool->fl_bitmap & (~0UL << (fl + 1));
 		if (!fl_map)
 		{
 			/* No free blocks available, memory has been exhausted. */

--- a/xmhf/xmhf/src/libbaremetal/libxmhfc/subr_prf.c
+++ b/xmhf/xmhf/src/libbaremetal/libxmhfc/subr_prf.c
@@ -629,23 +629,23 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				padc = '0';
 				goto reswitch;
 			}
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '1':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '2':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '3':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '4':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '5':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '6':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '7':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '8':
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case '9':
 			for (n = 0;; ++fmt) {
 				n = n * 10 + ch - '0';
@@ -782,7 +782,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			goto handle_nosign;
 		case 'X':
 			upper = 1;
-			__attribute__ ((fallthrough));
+			/* fallthrough */
 		case 'x':
 			base = 16;
 			goto handle_nosign;

--- a/xmhf/xmhf/src/libbaremetal/libxmhfc/subr_prf.c
+++ b/xmhf/xmhf/src/libbaremetal/libxmhfc/subr_prf.c
@@ -629,14 +629,30 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				padc = '0';
 				goto reswitch;
 			}
-		case '1': case '2': case '3': case '4':
-		case '5': case '6': case '7': case '8': case '9':
-				for (n = 0;; ++fmt) {
-					n = n * 10 + ch - '0';
-					ch = *fmt;
-					if (ch < '0' || ch > '9')
-						break;
-				}
+			__attribute__ ((fallthrough));
+		case '1':
+			__attribute__ ((fallthrough));
+		case '2':
+			__attribute__ ((fallthrough));
+		case '3':
+			__attribute__ ((fallthrough));
+		case '4':
+			__attribute__ ((fallthrough));
+		case '5':
+			__attribute__ ((fallthrough));
+		case '6':
+			__attribute__ ((fallthrough));
+		case '7':
+			__attribute__ ((fallthrough));
+		case '8':
+			__attribute__ ((fallthrough));
+		case '9':
+			for (n = 0;; ++fmt) {
+				n = n * 10 + ch - '0';
+				ch = *fmt;
+				if (ch < '0' || ch > '9')
+					break;
+			}
 			if (dot)
 				dwidth = n;
 			else
@@ -766,6 +782,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			goto handle_nosign;
 		case 'X':
 			upper = 1;
+			__attribute__ ((fallthrough));
 		case 'x':
 			base = 16;
 			goto handle_nosign;

--- a/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/cmdline.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/cmdline.c
@@ -112,11 +112,11 @@ static const cmdline_option_t g_tboot_cmdline_options[] = {
     { NULL, NULL }
 };
 
-static const cmdline_option_t g_linux_cmdline_options[] = {
-    { "vga", "" },
-    { "mem", "" },
-    { NULL, NULL }
-};
+/* static const cmdline_option_t g_linux_cmdline_options[] = { */
+/*     { "vga", "" }, */
+/*     { "mem", "" }, */
+/*     { NULL, NULL } */
+/* }; */
 /* static char g_linux_param_values[ARRAY_SIZE(g_linux_cmdline_options)][MAX_VALUE_LEN]; */
 static char g_tboot_param_values[ARRAY_SIZE(g_tboot_cmdline_options)][MAX_VALUE_LEN];
 

--- a/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/init.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/init.c
@@ -415,7 +415,7 @@ tb_error_t txt_verify_platform(void)
     
     /* check TXT supported */
     if(!txt_supports_txt()) {
-        printf("FATAL ERROR: TXT not suppported\n");
+        printf("FATAL ERROR: TXT not supported\n");
         HALT();
     }    
 

--- a/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/txt_acmod.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/txt_acmod.c
@@ -572,10 +572,10 @@ bool verify_acmod(acm_hdr_t *acm_hdr)
 /*         return false; */
 /*     } */
 
-    if ( size > params.acm_max_size ) {
-        printf("AC mod size too large: %x (max=%x)\n", size,
-               params.acm_max_size);
-        return false;
+/*     if ( size > params.acm_max_size ) { */
+/*         printf("AC mod size too large: %x (max=%x)\n", size, */
+/*                params.acm_max_size); */
+/*         return false; */
     }
 
     printf("AC mod size OK\n");

--- a/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/txt_acmod.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/txt_acmod.c
@@ -536,7 +536,7 @@ acm_hdr_t *copy_sinit(acm_hdr_t *sinit)
  */
 bool verify_acmod(acm_hdr_t *acm_hdr)
 {
-    getsec_parameters_t params;
+/*     getsec_parameters_t params; */
     uint32_t size;
     acm_info_table_t *info_table;
     txt_caps_t caps_mask = { 0 };

--- a/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/txt_acmod.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-bootloader/txt_acmod.c
@@ -576,7 +576,7 @@ bool verify_acmod(acm_hdr_t *acm_hdr)
 /*         printf("AC mod size too large: %x (max=%x)\n", size, */
 /*                params.acm_max_size); */
 /*         return false; */
-    }
+/*     } */
 
     printf("AC mod size OK\n");
 

--- a/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-baseplatform/arch/x86/bplt-x86.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-baseplatform/arch/x86/bplt-x86.c
@@ -56,12 +56,12 @@ u32 xmhf_baseplatform_arch_getcpuvendor(void){
 	u32 vendor_dword1, vendor_dword2, vendor_dword3;
 	u32 cpu_vendor;
 	asm(	"xor	%%eax, %%eax \n"
-				  "cpuid \n"		
-				  "mov	%%ebx, %0 \n"
-				  "mov	%%edx, %1 \n"
-				  "mov	%%ecx, %2 \n"
-			     :	//no inputs
-					 : "m"(vendor_dword1), "m"(vendor_dword2), "m"(vendor_dword3)
+					"cpuid \n"		
+					"mov	%%ebx, %0 \n"
+					"mov	%%edx, %1 \n"
+					"mov	%%ecx, %2 \n"
+					 : "=m"(vendor_dword1), "=m"(vendor_dword2), "=m"(vendor_dword3)
+					 : //no inputs
 					 : "eax", "ebx", "ecx", "edx" );
 
 	if(vendor_dword1 == AMD_STRING_DWORD1 && vendor_dword2 == AMD_STRING_DWORD2

--- a/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-eventhub/arch/x86/svm/peh-x86svm-main.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-eventhub/arch/x86/svm/peh-x86svm-main.c
@@ -74,13 +74,13 @@ static void _svm_handle_ioio(VCPU *vcpu, struct _svm_vmcbfields *vmcb, struct re
 	access_size = IO_SIZE_WORD;
   else
 	access_size = IO_SIZE_DWORD;
-	
-	//call our app handler
-	xmhf_smpguest_arch_x86svm_quiesce(vcpu);
-	app_ret_status=xmhf_app_handleintercept_portaccess(vcpu, r, ioinfo.fields.port, access_type, 
+  
+  //call our app handler
+  xmhf_smpguest_arch_x86svm_quiesce(vcpu);
+  app_ret_status=xmhf_app_handleintercept_portaccess(vcpu, r, ioinfo.fields.port, access_type, 
           access_size);
-    xmhf_smpguest_arch_x86svm_endquiesce(vcpu);
-	
+  xmhf_smpguest_arch_x86svm_endquiesce(vcpu);
+  
   
   if(app_ret_status == APP_IOINTERCEPT_CHAIN){
 	  if (ioinfo.fields.type){

--- a/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-smpguest/arch/x86/svm/smpg-x86svm.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-smpguest/arch/x86/svm/smpg-x86svm.c
@@ -458,7 +458,7 @@ void xmhf_smpguest_arch_x86svm_endquiesce(VCPU __attribute__((unused)) *vcpu){
         
         while(g_svm_quiesce_resume_counter < (g_midtable_numentries-1) );
 
-		vcpu->quiesced = 0;
+        vcpu->quiesced = 0;
         g_svm_quiesce=0;  // we are out of quiesce at this point
 
 

--- a/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-smpguest/arch/x86/vmx/smpg-x86vmx.c
+++ b/xmhf/xmhf/src/xmhf-core/xmhf-runtime/xmhf-smpguest/arch/x86/vmx/smpg-x86vmx.c
@@ -443,7 +443,7 @@ void xmhf_smpguest_arch_x86vmx_endquiesce(VCPU *vcpu){
         
         while(g_vmx_quiesce_resume_counter < (g_midtable_numentries-1) );
 
-		vcpu->quiesced=0;
+        vcpu->quiesced=0;
         g_vmx_quiesce=0;  // we are out of quiesce at this point
 
         //printf("\nCPU(0x%02x): all CPUs resumed successfully.", vcpu->id);


### PR DESCRIPTION
When the XMHF project is compiled on newer version of GCC, compile warnings cause build to fail. This PR tries to fix them.

Justifications on the changes
* `Makefile.in`
	* Disable `-Waddress-of-packed-member` (no easy fix)
	* Disable PIE (enabled automatically in newer version of GCC)
* `tlsf.c`
	* Fix constant type
* `subr_prf.c`
	* Explicit fallthrough to prevent warnings
* `cmdline.c`
	* Remove unused global static variable `g_linux_cmdline_options`
* `init.c`
	* Fix typo
* `txt_acmod.c`
	* Remove use of uninitialized variable `params` (this is an actual access to uninitialized variable in the code)
* `bplt-x86.c`
	* Fix incorrect inline assembly
* `peh-x86svm-main.c`
	* Fix indent
* `smpg-x86svm.c`
	* Fix indent
* `smpg-x86vmx.c`
	* Fix indent
