### PR TITLE
More fixes within _legacy_ TrustVisor hypapp

### DIFF
--- a/xmhf/hypapps/trustvisor/src/appmain.c
+++ b/xmhf/hypapps/trustvisor/src/appmain.c
@@ -584,7 +584,7 @@ u32 tv_app_handlehypercall(VCPU *vcpu, struct regs *r)
 
 /* EPT violation handler */
 u32 tv_app_handleintercept_hwpgtblviolation(VCPU *vcpu,
-                                            struct regs __attribute__((unused)) *r, u64 gpa, u64 gva, u64 violationcode)
+                                            struct regs *r, u64 gpa, u64 gva, u64 violationcode)
 {
   u32 ret;
 #if defined(__LDN_TV_INTEGRATION__)  
@@ -598,12 +598,12 @@ u32 tv_app_handleintercept_hwpgtblviolation(VCPU *vcpu,
 #if !defined(__LDN_TV_INTEGRATION__)  
   eu_trace("CPU(0x%02x): gva=%#llx, gpa=%#llx, code=%#llx", (int)vcpu->id,
           gva, gpa, violationcode);
-  if ((ret = hpt_scode_npf(vcpu, gpa, violationcode)) != 0) {
+  if ((ret = hpt_scode_npf(vcpu, gpa, violationcode, r)) != 0) {
     eu_trace("FATAL ERROR: Unexpected return value from page fault handling");
     HALT();
   }
 #else
-	ret = hpt_scode_npf(vcpu, gpa, violationcode);
+	ret = hpt_scode_npf(vcpu, gpa, violationcode, r);
 #endif //__LDN_TV_INTEGRATION__
 
 //#ifdef __MP_VERSION__

--- a/xmhf/hypapps/trustvisor/src/include/scode.h
+++ b/xmhf/hypapps/trustvisor/src/include/scode.h
@@ -163,8 +163,8 @@ int copy_to_current_guest(VCPU * vcpu, gva_t gvaddr, void *src, u32 len);
 
 /* PAL operations (HPT) */
 u32 hpt_scode_switch_scode(VCPU * vcpu);
-u32 hpt_scode_switch_regular(VCPU * vcpu);
-u32 hpt_scode_npf(VCPU * vcpu, u32 gpaddr, u64 errorcode);
+u32 hpt_scode_switch_regular(VCPU * vcpu, struct regs *r);
+u32 hpt_scode_npf(VCPU * vcpu, u32 gpaddr, u64 errorcode, struct regs *r);
 void hpt_scode_destroy_all(void);
 u32 scode_share(VCPU * vcpu, u32 scode_entry, u32 addr, u32 len);
 u32 scode_share_ranges(VCPU * vcpu, u32 scode_entry, u32 gva_base[], u32 gva_len[], u32 count);

--- a/xmhf/hypapps/trustvisor/src/include/scode.h
+++ b/xmhf/hypapps/trustvisor/src/include/scode.h
@@ -116,6 +116,7 @@ typedef struct whitelist_entry{
   u32 gpm_num;  /* guest parameter number */
 
   u32 saved_exception_intercepts;
+  int saved_cr0_em; /* save whether CR0.EM bit is set */
 
   tv_pal_section_int_t sections[TV_MAX_SECTIONS];
   size_t sections_num;

--- a/xmhf/hypapps/trustvisor/src/scode.c
+++ b/xmhf/hypapps/trustvisor/src/scode.c
@@ -1072,7 +1072,7 @@ u32 hpt_scode_switch_scode(VCPU * vcpu)
   return err;
 }
 
-u32 scode_unmarshall(VCPU * vcpu)
+u32 scode_unmarshall(VCPU * vcpu, struct regs *r)
 {
   u32 pm_addr_base, pm_addr;
   size_t i;
@@ -1165,13 +1165,17 @@ u32 scode_unmarshall(VCPU * vcpu)
 
     } //end for loop 
 
+  /* clear caller saved registers to prevent leaking PAL's secret */
+  r->ecx = 0;
+  r->edx = 0;
+
   err=0;
  out:
   return err;
 }
 
 //switch from sensitive code to regular code
-u32 hpt_scode_switch_regular(VCPU * vcpu)
+u32 hpt_scode_switch_regular(VCPU * vcpu, struct regs *r)
 {
   int curr=scode_curr[vcpu->id];
   u32 rv=1;
@@ -1183,7 +1187,7 @@ u32 hpt_scode_switch_regular(VCPU * vcpu)
   eu_trace("************************************");
 
   /* marshalling parameters back to regular code */
-  EU_CHKN( scode_unmarshall(vcpu));
+  EU_CHKN( scode_unmarshall(vcpu, r));
 
   /* whether or not marshalling succeeded, we switch back to reg world.
    * nothing below can fail.
@@ -1244,7 +1248,7 @@ static bool hpt_error_wasInsnFetch(VCPU *vcpu, u64 errorcode)
 #endif //__LDN_TV_INTEGRATION__
 
 /*  EPT violation handler */
-u32 hpt_scode_npf(VCPU * vcpu, u32 gpaddr, u64 errorcode)
+u32 hpt_scode_npf(VCPU * vcpu, u32 gpaddr, u64 errorcode, struct regs *r)
 {
   int index = -1;
 
@@ -1287,7 +1291,7 @@ u32 hpt_scode_npf(VCPU * vcpu, u32 gpaddr, u64 errorcode)
     /* valid return point, switch from sensitive code to regular code */
 
     /* XXX FIXME: now return ponit is extracted from regular code stack, only support one scode function call */
-    EU_CHKN( hpt_scode_switch_regular(vcpu));
+    EU_CHKN( hpt_scode_switch_regular(vcpu, r));
     *curr = -1;
   } else if ((*curr >=0) && (index >= 0)) {
     /* sensitive code to sensitive code */

--- a/xmhf/hypapps/trustvisor/src/scode.c
+++ b/xmhf/hypapps/trustvisor/src/scode.c
@@ -1034,7 +1034,7 @@ u32 hpt_scode_switch_scode(VCPU * vcpu)
 
   /* restore CR0.EM, check that CR0.EM is set during PAL */
   {
-    ulong_t cr0 = VCPU_gcr0(vcpu);
+    u32 cr0 = VCPU_gcr0(vcpu);
     EU_CHK((cr0 & CR0_EM) == CR0_EM);
     if (!whitelist[curr].saved_cr0_em) {
       cr0 &= ~CR0_EM;
@@ -1233,7 +1233,7 @@ u32 hpt_scode_switch_regular(VCPU * vcpu, struct regs *r)
 
   /* save and set CR0.EM, which disables FPU (not supported by TrustVisor) */
   {
-    ulong_t cr0 = VCPU_gcr0(vcpu);
+    u32 cr0 = VCPU_gcr0(vcpu);
     whitelist[curr].saved_cr0_em = !!(cr0 & CR0_EM);
     cr0 |= CR0_EM;
     VCPU_gcr0_set(vcpu, cr0);

--- a/xmhf/xmhf/src/xmhf-core/include/arch/x86/xmhf-baseplatform-arch-x86.h
+++ b/xmhf/xmhf/src/xmhf-core/include/arch/x86/xmhf-baseplatform-arch-x86.h
@@ -436,6 +436,29 @@ static inline void VCPU_grsp_set(VCPU *vcpu, u64 val)
   }
 }
 
+static inline u64 VCPU_gcr0(VCPU *vcpu)
+{
+  if (vcpu->cpu_vendor == CPU_VENDOR_INTEL) {
+    return vcpu->vmcs.guest_CR0;
+  } else if (vcpu->cpu_vendor == CPU_VENDOR_AMD) {
+    return ((struct _svm_vmcbfields*)vcpu->vmcb_vaddr_ptr)->cr0;
+  } else {
+    HALT_ON_ERRORCOND(false);
+    return 0;
+  }
+}
+
+static inline void VCPU_gcr0_set(VCPU *vcpu, u64 cr0)
+{
+  if (vcpu->cpu_vendor == CPU_VENDOR_INTEL) {
+    vcpu->vmcs.guest_CR0 = cr0;
+  } else if (vcpu->cpu_vendor == CPU_VENDOR_AMD) {
+    ((struct _svm_vmcbfields*)vcpu->vmcb_vaddr_ptr)->cr0 = cr0;
+  } else {
+    HALT_ON_ERRORCOND(false);
+  }
+}
+
 static inline u64 VCPU_gcr3(VCPU *vcpu)
 {
   if (vcpu->cpu_vendor == CPU_VENDOR_INTEL) {


### PR DESCRIPTION
1. Clear caller saved registers during `scode_unmarshall`. This prevents leaking secret data of PALs through EDX and ECX registers.
2. Disable FPU and SIMD instructions in the PAL. Assuming no existing PALs are using these.